### PR TITLE
[fix]修复github action以及新克隆库的构建错误

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,8 +3,8 @@ description: A new Flutter project.
 
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-# 璇蜂繚璇?'package:we_pei_yang_flutter/commons/environment/config.dart'
-# 涓殑 version 鍜?versionCode 淇濇寔涓€鑷?
+# 请确保 'package:we_pei_yang_flutter/commons/environment/config.dart'
+# 中的 version 和 versionCode 保持一致
 version: 4.4.10+160
 
 # Build:
@@ -31,7 +31,7 @@ dependencies:
 
   pointycastle: ^3.1.1
   xml: ^6.5.0
-  # 鏄剧ず浜岀淮鐮?
+  # 显示二维码
   syncfusion_flutter_barcodes: ^25.1.42
 
   badges: ^3.1.1
@@ -108,6 +108,8 @@ dependencies:
   uuid: ^4.3.3
 
   webview_flutter: ^2.0.13 # TODO: update the new webview package
+
+  wechat_picker_library: 1.0.5  # IMPORTANT: >= 1.0.6 leads to build failure (The package requires an incompatible Flutter version)
   wechat_assets_picker: any
   window_manager: ^0.3.8
 
@@ -117,7 +119,7 @@ dependencies:
   #  image_size_getter_http_input: ^2.0.0
   flutter_staggered_grid_view: ^0.4.0
 
-  # 鐢ㄤ簬鍥剧墖鍔犺浇鍗犱綅绗?
+  # 用于图片加载占位符
   transparent_image: ^2.0.1
 
   package_info_plus: ^6.0.0


### PR DESCRIPTION
1.修复库文件中注释的乱码
2.强制固定wechat_picker_library（wechat_assets_picker的前置库）版本为1.0.5（若不固定则默认安装1.0.6，该新版本使用了更高版本 的flutter特性，使得当前开发环境下的flutter无法成功构建，进而导致github action长达半年的构建错误）