### PR TITLE
refactor: 将友盟SDK初始化移至用户同意隐私协议之后

### DIFF
--- a/android/app/src/main/kotlin/com/twt/service/WBYApplication.kt
+++ b/android/app/src/main/kotlin/com/twt/service/WBYApplication.kt
@@ -3,13 +3,9 @@ package com.twt.service
 import android.app.ActivityManager
 import android.app.Application
 import android.content.Context
-import android.os.Build
 import android.os.Process
 import com.twt.service.hot_fix.HotFixPreference
 import com.twt.service.push.model.Event
-import com.umeng.cconfig.RemoteConfigSettings
-import com.umeng.cconfig.UMRemoteConfig
-import com.umeng.commonsdk.UMConfigure
 import io.flutter.FlutterInjector
 import java.lang.ref.WeakReference
 
@@ -23,20 +19,6 @@ class WBYApplication : Application() {
         super.onCreate()
         runOnMainProcess {
             context = WeakReference(applicationContext)
-            // 初始化友盟
-            if (BuildConfig.LOG_OUTPUT) {
-                UMConfigure.setLogEnabled(true)
-            }
-            // 友盟在线参数
-            UMRemoteConfig.getInstance().apply {
-                setDefaults(R.xml.cloud_config_parms)
-                setConfigSettings(
-                    RemoteConfigSettings.Builder().setAutoUpdateModeEnabled(true).build()
-                )
-            }
-
-
-            UMConfigure.preInit(applicationContext, "60464782b8c8d45c1390e7e3", Build.BRAND)
             // Build 类获取系统信息
             // https://blog.csdn.net/duyiqun/article/details/54882735
             // 加载flutter
@@ -53,7 +35,7 @@ class WBYApplication : Application() {
 //        FlutterInjector.instance().flutterLoader().startInitialization(this)
 //    }
 
-    // 个推会创建一条子进程用来接收推送，所以初始化友盟和flutter只能在主进程执行
+    // 个推会创建一条子进程用来接收推送，所以flutter初始化只能在主进程执行
     fun runOnMainProcess(func: () -> Unit) {
         func.takeIf {
             val pid = Process.myPid()

--- a/android/app/src/main/kotlin/com/twt/service/statistics/WbyStatisticsPlugin.kt
+++ b/android/app/src/main/kotlin/com/twt/service/statistics/WbyStatisticsPlugin.kt
@@ -5,7 +5,11 @@ import android.util.Log
 import com.twt.service.WBYApplication
 import com.twt.service.common.LogUtil
 import com.twt.service.common.WbyPlugin
+import com.twt.service.BuildConfig
+import com.twt.service.R
 import com.umeng.analytics.MobclickAgent
+import com.umeng.cconfig.RemoteConfigSettings
+import com.umeng.cconfig.UMRemoteConfig
 import com.umeng.commonsdk.UMConfigure
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
@@ -37,6 +41,16 @@ class WbyStatisticsPlugin : WbyPlugin() {
     private fun initCommon() {
 
 //        val buildContext = WBYApplication.context?.get() ?: return
+        if (BuildConfig.LOG_OUTPUT) {
+            UMConfigure.setLogEnabled(true)
+        }
+        UMRemoteConfig.getInstance().apply {
+            setDefaults(R.xml.cloud_config_parms)
+            setConfigSettings(
+                RemoteConfigSettings.Builder().setAutoUpdateModeEnabled(true).build()
+            )
+        }
+        UMConfigure.preInit(context, "60464782b8c8d45c1390e7e3", Build.BRAND)
         UMConfigure.init(
             context,
             "60464782b8c8d45c1390e7e3",


### PR DESCRIPTION
- 移除 WBYApplication.onCreate 中的友盟预初始化和在线参数配置
- 将所有友盟初始化逻辑集中到 WbyStatisticsPlugin.initCommon()
- 确保友盟SDK数据采集仅在用户同意隐私协议后才开始